### PR TITLE
Add anchored diff for large files

### DIFF
--- a/difflib.go
+++ b/difflib.go
@@ -20,17 +20,18 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 )
 
 // DeltaType describes the relationship of elements in two
 // sequences. The following table provides a summary:
 //
-//    Constant    Code   Meaning
-//   ----------  ------ ---------------------------------------
-//    Common      " "    The element occurs in both sequences.
-//    LeftOnly    "-"    The element is unique to sequence 1.
-//    RightOnly   "+"    The element is unique to sequence 2.
+//	 Constant    Code   Meaning
+//	----------  ------ ---------------------------------------
+//	 Common      " "    The element occurs in both sequences.
+//	 LeftOnly    "-"    The element is unique to sequence 1.
+//	 RightOnly   "+"    The element is unique to sequence 2.
 type DeltaType int
 
 const (
@@ -53,9 +54,9 @@ func (t DeltaType) String() string {
 }
 
 type DiffRecord struct {
-	Payload string
-	Delta   DeltaType
-	LineLeft int
+	Payload   string
+	Delta     DeltaType
+	LineLeft  int
 	LineRight int
 }
 
@@ -80,7 +81,7 @@ func Diff(seq1, seq2 []string) (diff []DiffRecord) {
 	diff = append(diff, diffRes...)
 
 	for i, content := range seq1[len(seq1)-end:] {
-		diff = append(diff, DiffRecord{content, Common, len(seq1)-end+i, len(seq2)-end+i})
+		diff = append(diff, DiffRecord{content, Common, len(seq1) - end + i, len(seq2) - end + i})
 	}
 	return
 }
@@ -211,16 +212,248 @@ func compute(seq1, seq2 []string, startLine int) (diff []DiffRecord) {
 	i, j := len(seq1), len(seq2)
 	for i > 0 || j > 0 {
 		if i > 0 && matrix[i][j] == matrix[i-1][j] {
-			diff = append(diff, DiffRecord{seq1[len(seq1)-i], LeftOnly, startLine+len(seq1)-i, startLine+len(seq2)-j})
+			diff = append(diff, DiffRecord{seq1[len(seq1)-i], LeftOnly, startLine + len(seq1) - i, startLine + len(seq2) - j})
 			i--
 		} else if j > 0 && matrix[i][j] == matrix[i][j-1] {
-			diff = append(diff, DiffRecord{seq2[len(seq2)-j], RightOnly, startLine+len(seq1)-i, startLine+len(seq2)-j})
+			diff = append(diff, DiffRecord{seq2[len(seq2)-j], RightOnly, startLine + len(seq1) - i, startLine + len(seq2) - j})
 			j--
 		} else if i > 0 && j > 0 {
-			diff = append(diff, DiffRecord{seq1[len(seq1)-i], Common, startLine+len(seq1)-i, startLine+len(seq2)-j})
+			diff = append(diff, DiffRecord{seq1[len(seq1)-i], Common, startLine + len(seq1) - i, startLine + len(seq2) - j})
 			i--
 			j--
 		}
 	}
 	return
+}
+
+// A pair is a pair of values tracked for both the x and y side of a diff.
+// It is typically a pair of line indexes.
+type pair struct{ x, y int }
+
+// Diff returns an anchored diff of the two texts old and new
+// in the “unified diff” format. If old and new are identical,
+// Diff returns a nil slice (no output).
+//
+// Unix diff implementations typically look for a diff with
+// the smallest number of lines inserted and removed,
+// which can in the worst case take time quadratic in the
+// number of lines in the texts. As a result, many implementations
+// either can be made to run for a long time or cut off the search
+// after a predetermined amount of work.
+//
+// In contrast, this implementation looks for a diff with the
+// smallest number of “unique” lines inserted and removed,
+// where unique means a line that appears just once in both old and new.
+// We call this an “anchored diff” because the unique lines anchor
+// the chosen matching regions. An anchored diff is usually clearer
+// than a standard diff, because the algorithm does not try to
+// reuse unrelated blank lines or closing braces.
+// The algorithm also guarantees to run in O(n log n) time
+// instead of the standard O(n²) time.
+//
+// Some systems call this approach a “patience diff,” named for
+// the “patience sorting” algorithm, itself named for a solitaire card game.
+// We avoid that name for two reasons. First, the name has been used
+// for a few different variants of the algorithm, so it is imprecise.
+// Second, the name is frequently interpreted as meaning that you have
+// to wait longer (to be patient) for the diff, meaning that it is a slower algorithm,
+// when in fact the algorithm is faster than the standard one.
+func AnchoredDiff(seq1, seq2 []string) []DiffRecord {
+	diff := []DiffRecord{}
+	equalDiff := []DiffRecord{}
+
+	// Loop over matches to consider,
+	// expanding each match to include surrounding lines,
+	// and then printing diff chunks.
+	// To avoid setup/teardown cases outside the loop,
+	// tgs returns a leading {0,0} and trailing {len(x), len(y)} pair
+	// in the sequence of matches.
+	var (
+		done  pair       // printed up to x[:done.x] and y[:done.y]
+		chunk pair       // start lines of current chunk
+		count pair       // number of lines from each side in current chunk
+		ctext []struct{} // lines for current chunk
+	)
+	for _, m := range tgs(seq1, seq2) {
+		if m.x < done.x {
+			// Already handled scanning forward from earlier match.
+			continue
+		}
+
+		// Expand matching lines as far possible,
+		// establishing that x[start.x:end.x] == y[start.y:end.y].
+		// Note that on the first (or last) iteration we may (or definitely do)
+		// have an empty match: start.x==end.x and start.y==end.y.
+		start := m
+		for start.x > done.x && start.y > done.y && seq1[start.x-1] == seq2[start.y-1] {
+			start.x--
+			start.y--
+		}
+		end := m
+		for end.x < len(seq1) && end.y < len(seq2) && seq1[end.x] == seq2[end.y] {
+			equalDiff = append(equalDiff, DiffRecord{seq1[end.x], Common, end.x, end.y})
+			end.x++
+			end.y++
+		}
+
+		// If both sequences are identical, then add 'common' diff for all lines
+		if start.x == 0 && start.y == 0 && end.x == len(seq1) && end.y == len(seq2) {
+			diff = append(diff, equalDiff...)
+		}
+
+		// Emit the mismatched lines before start into this chunk.
+		// (No effect on first sentinel iteration, when start = {0,0}.)
+		for _, s := range seq1[done.x:start.x] {
+			diff = append(diff, DiffRecord{s, LeftOnly, chunk.x + count.x, chunk.y + count.y})
+			ctext = append(ctext, struct{}{})
+			count.x++
+		}
+		for _, s := range seq2[done.y:start.y] {
+			diff = append(diff, DiffRecord{s, RightOnly, chunk.x + count.x, chunk.y + count.y})
+			ctext = append(ctext, struct{}{})
+			count.y++
+		}
+
+		// If we're not at EOF and have too few common lines,
+		// the chunk includes all the common lines and continues.
+		const C = 30 // maximum number of context lines
+		if (end.x < len(seq1) || end.y < len(seq2)) &&
+			(end.x-start.x < C || (len(ctext) > 0 && end.x-start.x < 2*C)) {
+			for _, s := range seq1[start.x:end.x] {
+				ctext = append(ctext, struct{}{})
+				diff = append(diff, DiffRecord{s, Common, chunk.x + count.x, chunk.y + count.y})
+				count.x++
+				count.y++
+			}
+			done = end
+			continue
+		}
+
+		// End chunk with common lines for context.
+		if len(ctext) > 0 {
+			n := end.x - start.x
+			if n > C {
+				n = C
+			}
+			for _, s := range seq1[start.x : start.x+n] {
+				ctext = append(ctext, struct{}{})
+				diff = append(diff, DiffRecord{s, Common, chunk.x + count.x, chunk.y + count.y})
+				count.x++
+				count.y++
+			}
+			done = pair{start.x + n, start.y + n}
+
+			// Format and emit chunk.
+			// Convert line numbers to 1-indexed.
+			// Special case: empty file shows up as 0,0 not 1,0.
+			if count.x > 0 {
+				chunk.x++
+			}
+			if count.y > 0 {
+				chunk.y++
+			}
+			count.x = 0
+			count.y = 0
+			ctext = ctext[:0]
+		}
+
+		// If we reached EOF, we're done.
+		if end.x >= len(seq1) && end.y >= len(seq2) {
+			break
+		}
+
+		// Otherwise start a new chunk.
+		chunk = pair{end.x - C, end.y - C}
+		for _, s := range seq1[chunk.x:end.x] {
+			ctext = append(ctext, struct{}{})
+			diff = append(diff, DiffRecord{s, Common, chunk.x + count.x, chunk.y + count.y})
+			count.x++
+			count.y++
+		}
+		done = end
+	}
+
+	return diff
+}
+
+// tgs returns the pairs of indexes of the longest common subsequence
+// of unique lines in x and y, where a unique line is one that appears
+// once in x and once in y.
+//
+// The longest common subsequence algorithm is as described in
+// Thomas G. Szymanski, “A Special Case of the Maximal Common
+// Subsequence Problem,” Princeton TR #170 (January 1975),
+// available at https://research.swtch.com/tgs170.pdf.
+func tgs(x, y []string) []pair {
+	// Count the number of times each string appears in a and b.
+	// We only care about 0, 1, many, counted as 0, -1, -2
+	// for the x side and 0, -4, -8 for the y side.
+	// Using negative numbers now lets us distinguish positive line numbers later.
+	m := make(map[string]int)
+	for _, s := range x {
+		if c := m[s]; c > -2 {
+			m[s] = c - 1
+		}
+	}
+	for _, s := range y {
+		if c := m[s]; c > -8 {
+			m[s] = c - 4
+		}
+	}
+
+	// Now unique strings can be identified by m[s] = -1+-4.
+	//
+	// Gather the indexes of those strings in x and y, building:
+	//	xi[i] = increasing indexes of unique strings in x.
+	//	yi[i] = increasing indexes of unique strings in y.
+	//	inv[i] = index j such that x[xi[i]] = y[yi[j]].
+	var xi, yi, inv []int
+	for i, s := range y {
+		if m[s] == -1+-4 {
+			m[s] = len(yi)
+			yi = append(yi, i)
+		}
+	}
+	for i, s := range x {
+		if j, ok := m[s]; ok && j >= 0 {
+			xi = append(xi, i)
+			inv = append(inv, j)
+		}
+	}
+
+	// Apply Algorithm A from Szymanski's paper.
+	// In those terms, A = J = inv and B = [0, n).
+	// We add sentinel pairs {0,0}, and {len(x),len(y)}
+	// to the returned sequence, to help the processing loop.
+	J := inv
+	n := len(xi)
+	T := make([]int, n)
+	L := make([]int, n)
+	for i := range T {
+		T[i] = n + 1
+	}
+	for i := 0; i < n; i++ {
+		k := sort.Search(n, func(k int) bool {
+			return T[k] >= J[i]
+		})
+		T[k] = J[i]
+		L[i] = k + 1
+	}
+	k := 0
+	for _, v := range L {
+		if k < v {
+			k = v
+		}
+	}
+	seq := make([]pair, 2+k)
+	seq[1+k] = pair{len(x), len(y)} // sentinel at end
+	lastj := n
+	for i := n - 1; i >= 0; i-- {
+		if L[i] == k && J[i] < lastj {
+			seq[k] = pair{xi[i], yi[J[i]]}
+			k--
+		}
+	}
+	seq[0] = pair{0, 0} // sentinel at start
+	return seq
 }

--- a/difflib_test.go
+++ b/difflib_test.go
@@ -74,11 +74,12 @@ func TestNumEqualStartAndEndElements(t *testing.T) {
 }
 
 var diffTests = []struct {
-	Seq1     string
-	Seq2     string
-	Diff     []DiffRecord
-	HtmlDiff string
-	PPDiff   string
+	Seq1         string
+	Seq2         string
+	Diff         []DiffRecord
+	HtmlDiff     string
+	PPDiff       string
+	AnchoredDiff []DiffRecord
 }{
 	{
 		"",
@@ -88,8 +89,11 @@ var diffTests = []struct {
 		},
 		`<tr><td class="line-num">1</td><td><pre></pre></td><td><pre></pre></td><td class="line-num">1</td></tr>
 `,
-`  0,  0   |
+		`  0,  0   |
 `,
+		[]DiffRecord{
+			{"", Common, 0, 0},
+		},
 	},
 
 	{
@@ -102,6 +106,9 @@ var diffTests = []struct {
 `,
 		`  0,  0   |same
 `,
+		[]DiffRecord{
+			{"same", Common, 0, 0},
+		},
 	},
 
 	{
@@ -129,6 +136,12 @@ three
   2,  2   |three
   3,  3   |
 `,
+		[]DiffRecord{
+			{"one", Common, 0, 0},
+			{"two", Common, 1, 1},
+			{"three", Common, 2, 2},
+			{"", Common, 3, 3},
+		},
 	},
 
 	{
@@ -159,6 +172,13 @@ three
   2,  2   |three
   3,  3   |
 `,
+		[]DiffRecord{
+			{"one", Common, 0, 0},
+			{"two", LeftOnly, 1, 1},
+			{"five", RightOnly, 2, 1},
+			{"three", Common, 2, 2},
+			{"", Common, 3, 3},
+		},
 	},
 
 	{
@@ -203,6 +223,16 @@ Wagner
   5,  4 - |Wagner
   6,  4   |
 `,
+		[]DiffRecord{
+			{"Beethoven", Common, 0, 0},
+			{"Bach", Common, 1, 1},
+			{"Mozart", LeftOnly, 2, 2},
+			{"Brahms", RightOnly, 3, 2},
+			{"Chopin", Common, 3, 3},
+			{"Liszt", RightOnly, 4, 4},
+			{"Wagner", RightOnly, 4, 5},
+			{"", Common, 4, 6},
+		},
 	},
 
 	{
@@ -256,6 +286,86 @@ allegro
   6,  4 + |lento
   6,  5   |
 `,
+		[]DiffRecord{
+			{"adagio", LeftOnly, 0, 0},
+			{"vivace", LeftOnly, 1, 0},
+			{"adagio adagio", RightOnly, 2, 0},
+			{"staccato", RightOnly, 2, 1},
+			{"staccato legato", Common, 2, 2},
+			{"presto", LeftOnly, 3, 3},
+			{"lento", LeftOnly, 4, 3},
+			{"staccato", RightOnly, 5, 3},
+			{"legato", RightOnly, 5, 4},
+			{"allegro", RightOnly, 5, 5},
+			{"", Common, 5, 6},
+		},
+	},
+
+	{
+		`alpha
+beta
+gama
+delta
+beta
+pi
+`,
+		`solid
+liquid
+gas
+beta
+plasma
+`,
+		[]DiffRecord{
+			{"alpha", LeftOnly, 0, 0},
+			{"beta", LeftOnly, 1, 0},
+			{"gama", LeftOnly, 2, 0},
+			{"delta", LeftOnly, 3, 0},
+			{"solid", RightOnly, 4, 0},
+			{"liquid", RightOnly, 4, 1},
+			{"gas", RightOnly, 4, 2},
+			{"beta", Common, 4, 3},
+			{"pi", LeftOnly, 5, 4},
+			{"plasma", RightOnly, 6, 4},
+			{"", Common, 6, 5},
+		},
+		`<tr><td class="line-num">1</td><td class="deleted"><pre>alpha</pre></td><td></td><td class="line-num"></td></tr>
+<tr><td class="line-num">2</td><td class="deleted"><pre>beta</pre></td><td></td><td class="line-num"></td></tr>
+<tr><td class="line-num">3</td><td class="deleted"><pre>gama</pre></td><td></td><td class="line-num"></td></tr>
+<tr><td class="line-num">4</td><td class="deleted"><pre>delta</pre></td><td></td><td class="line-num"></td></tr>
+<tr><td class="line-num"></td><td></td><td class="added"><pre>solid</pre></td><td class="line-num">1</td></tr>
+<tr><td class="line-num"></td><td></td><td class="added"><pre>liquid</pre></td><td class="line-num">2</td></tr>
+<tr><td class="line-num"></td><td></td><td class="added"><pre>gas</pre></td><td class="line-num">3</td></tr>
+<tr><td class="line-num">5</td><td><pre>beta</pre></td><td><pre>beta</pre></td><td class="line-num">4</td></tr>
+<tr><td class="line-num">6</td><td class="deleted"><pre>pi</pre></td><td></td><td class="line-num"></td></tr>
+<tr><td class="line-num"></td><td></td><td class="added"><pre>plasma</pre></td><td class="line-num">5</td></tr>
+<tr><td class="line-num">7</td><td><pre></pre></td><td><pre></pre></td><td class="line-num">6</td></tr>
+`,
+		`  0,  0 - |solid
+  1,  0 - |liquid
+  2,  0 - |gas
+  3,  0 + |alpha
+  3,  1 + |beta
+  3,  2 + |gama
+  3,  3 + |delta
+  3,  4   |beta
+  4,  5 - |plasma
+  5,  5 + |pi
+  5,  6   |
+`,
+		[]DiffRecord{
+			{"alpha", LeftOnly, 0, 0},
+			{"beta", LeftOnly, 1, 0},
+			{"gama", LeftOnly, 2, 0},
+			{"delta", LeftOnly, 3, 0},
+			{"beta", LeftOnly, 4, 0},
+			{"pi", LeftOnly, 5, 0},
+			{"solid", RightOnly, 6, 0},
+			{"liquid", RightOnly, 6, 1},
+			{"gas", RightOnly, 6, 2},
+			{"beta", RightOnly, 6, 3},
+			{"plasma", RightOnly, 6, 4},
+			{"", Common, 6, 5},
+		},
 	},
 }
 
@@ -282,5 +392,10 @@ func TestDiff(t *testing.T) {
 				i, seq1, seq2, ppDiff, test.PPDiff)
 		}
 
+		anchoredDiff := AnchoredDiff(seq1, seq2)
+		if !reflect.DeepEqual(anchoredDiff, test.AnchoredDiff) {
+			t.Errorf("%d. AnchoredDiff(%v, %v) => %v, expected %v",
+				i, seq1, seq2, anchoredDiff, test.Diff)
+		}
 	}
 }


### PR DESCRIPTION
Diff is memory-hungry as it uses a matrix of int to calculate the longest common subsequence for diff. Anchored diff can be used to calculate diff for large files (say no of lines >500). It is based on go's internal diff package (https://cs.opensource.google/go/go/+/refs/tags/go1.21.3:src/internal/diff/diff.go)